### PR TITLE
use commit SHA as devtag

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,7 @@ var options = {
         "key": "AKIAJPKHVT3XFBAKFZWA",
         "secret": process.env.SECRET_KEY
     },
-    devTag: 'test03'
+    devTag: process.env.COMMIT_SHA
 };
 
 var appFilename = 'app.js';


### PR DESCRIPTION
So I turned off Travis for PRs until we figure out how to make it not publish until AFTER PRs are merged (vs when they are created). But we still also want Travis to run the tests so I'm looking through the docs. I also made Travis only build on commits to master so hopefully the "use commit SHA as devtag" commit did not kick off a build. alternatively, I learned if you add [skip ci] to the commit message, travis will not build it.

@capajon 
