### PR TITLE
display test coverage and don't compute html twice

### DIFF
--- a/test/example.karma.conf.js
+++ b/test/example.karma.conf.js
@@ -9,8 +9,8 @@ module.exports = function (config) {
 		coverageReporter: {
 			dir : 'test/coverage/example',
 			reporters: [
-				{ type: 'html', subdir: 'html' },
-				{ type: 'lcov', subdir: 'lcov' }
+				{ type: 'lcov', subdir: 'lcov' },
+				{ type: 'text'}
 			]
 		},
 		frameworks: ['browserify', 'mocha', 'chai', 'sinon'],


### PR DESCRIPTION
the `lcov` reporter runs html so there's no need to run it twice (which is why I took out the html reporter)
