### PR TITLE
add gulp task to open coverage html file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,8 @@ var frau = require('free-range-app-utils'),
 	pjson = require('./package.json'),
 	pg = require('peanut-gallery'),
 	publisher = require('gulp-frau-publisher'),
-	semver = require('semver');
+	semver = require('semver'),
+	open = require("open");
 
 var setValidDevTagOrVersion = function(options) {
 	var travisTag = process.env.TRAVIS_TAG,
@@ -66,4 +67,8 @@ gulp.task('publish-release', function(cb) {
 			});
 
 		});
+});
+
+gulp.task('coverage', function() {
+	open('./test/coverage/example/lcov/lcov-report/index.html');
 });

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "report-coverage": "lcov-result-merger 'test/coverage/*/lcov/lcov.info' | coveralls",
     "clean": "rimraf dist && mkdir dist",
     "publish-release": "npm run build:release -s && gulp publish-release",
-    "test:example": "karma start ./test/example.karma.conf.js --single-run",
+    "test:example": "karma start ./test/example.karma.conf.js --single-run && echo Run 'gulp coverage' for more details.",
     "test:lint": "jsxhint --exclude test/coverage/**/*.js* src test gulpfile.js",
     "test": "npm run test:lint -s && npm run test:example"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "prebuild": "npm run clean -s && npm run test:lint",
-	"build": "npm run build:local",
+    "build": "npm run build:local",
     "build:local": "npm run build:js && npm run build:appconfig-local",
     "build:appconfig-local": "gulp appconfig-local",
     "build:appconfig-release": "gulp appconfig-release",
@@ -41,6 +41,7 @@
     "karma-sinon": "^1.0.4",
     "lcov-result-merger": "^1.0.2",
     "mocha": "^2.2.1",
+    "open": "0.0.5",
     "peanut-gallery": "^0.0.4",
     "rimraf": "^2.3.2",
     "semver": "^4.3.1",


### PR DESCRIPTION
Not really sure if this belongs in a skeleton app.

My thinking here is manually opening the html file ruins my flow (I have to open windows explorer or memorize the path and type it all out) and I'll probably never look at it unless its convenient.

The path is hardcoded. I could get the path from example.karma.conf.js but then that path would be hardcoded so I figured why bother because if one of the paths changes, the other will as well most likely.
